### PR TITLE
Adding check for identifying the correct pem file on different servers

### DIFF
--- a/R/klink_hadoop.R
+++ b/R/klink_hadoop.R
@@ -65,7 +65,9 @@ klink_hadoop <- function(environment, schema, connection_pane = TRUE){
                    HiveServerType=2,
                    AllowSelfSignedServerCert=1,
                    SSL=1,
-                   TrustedCerts='/usr/rstudio2/serverpro/certs/hive.pem',
+                   TrustedCerts=ifelse(environment == "PROD",
+                                       '/usr/rstudio/serverpro/certs/hive_prod.pem',
+                                       '/usr/rstudio2/serverpro/certs/hive.pem'),
                    HttpPathPrefix='/cliservice')
 
     # Updates connections pane w db structure


### PR DESCRIPTION
The file paths for the pem files on Dev and Prod are different. I added an ifelse statement to do a quick check for the environment and set the path automatically depending on the server.